### PR TITLE
Fix Makefile for the 20_password project

### DIFF
--- a/20_password/Makefile
+++ b/20_password/Makefile
@@ -6,4 +6,4 @@ test: words
 	pytest -xv test.py unit.py
 
 words:
-	[[ ! -f $(WORDS) ]] && (cd ../inputs && unzip words.txt.zip)
+	[[ -f $(WORDS) ]] || (cd ../inputs && unzip words.txt.zip)


### PR DESCRIPTION
The `[[ ! -f $(WORDS) ]] && ...` check short circuit evaluates to false if the file exists and exits with 1. This causes the Makefile to throw an error when `make test` is run for the second time, because the file is already unzipped at that time. The fixed `[[ -f $(WORDS) ]] || ...` check short circuit evaluates to true if the file exists and exits with 0.