### PR TITLE
Update instances of ’ char(8217) to ' char(39)

### DIFF
--- a/inputs/sonnet-29.txt
+++ b/inputs/sonnet-29.txt
@@ -1,17 +1,17 @@
 Sonnet 29
 William Shakespeare
 
-When, in disgrace with fortune and men’s eyes,
+When, in disgrace with fortune and men's eyes,
 I all alone beweep my outcast state,
 And trouble deaf heaven with my bootless cries,
 And look upon myself and curse my fate,
 Wishing me like to one more rich in hope,
 Featured like him, like him with friends possessed,
-Desiring this man’s art and that man’s scope,
+Desiring this man's art and that man's scope,
 With what I most enjoy contented least;
 Yet in these thoughts myself almost despising,
 Haply I think on thee, and then my state,
 (Like to the lark at break of day arising
-From sullen earth) sings hymns at heaven’s gate;
+From sullen earth) sings hymns at heaven's gate;
 For thy sweet love remembered such wealth brings
 That then I scorn to change my state with kings.


### PR DESCRIPTION
The inputs/sonnet-29.txt file is using a non-standard apostrophe, which could potentially cause some issues with readers' regex patterns. This generally happens if text is brought in from somewhere with a non-standard character set, like an MS word doc or something similar.